### PR TITLE
Use border width instead of edge width for points

### DIFF
--- a/src/napari_molecule_reader/molecule_reader.py
+++ b/src/napari_molecule_reader/molecule_reader.py
@@ -110,7 +110,7 @@ def read_molecule(path):
 
         bond_kwargs = dict(
             name=f'{name} - {ass} - bonds',
-            edge_width=5,
+            border_width=5,
         )
 
         layers.extend([

--- a/src/napari_molecule_reader/molecule_reader.py
+++ b/src/napari_molecule_reader/molecule_reader.py
@@ -104,7 +104,7 @@ def read_molecule(path):
             properties=tile(properties, ass),
             size=tile(sizes, ass),
             face_color=tile(colors, ass),
-            edge_width=0,
+            border_width=0,
             shading='spherical',
         )
 


### PR DESCRIPTION
Closes #8

`border_width` has been available since napari 0.5.0. I thought about implementing more complicated logic to continue supporting 0.4.x but I thought it probably wasn't necessary, let me know if you'd prefer that.